### PR TITLE
Subversion dropdown converted to buttons

### DIFF
--- a/assets/docs/scss/custom/structure/_sidebar.scss
+++ b/assets/docs/scss/custom/structure/_sidebar.scss
@@ -285,6 +285,20 @@
             }
         }
 
+        .sidebar-subversion-btn-group {
+            display: flex;
+            gap: 0.5rem;
+
+            padding-left: 1rem;
+            padding-right: 0.25rem;
+            margin-top: 18px;
+            margin-bottom: -8px;
+
+            .btn {
+                flex: 1 1 auto;
+            }
+        }
+
         .sidebar-header,
         .sidebar-menu {
             // border-top: 1px solid var(--sidebar-border-color);

--- a/exampleSite2/hugo-gateway.toml
+++ b/exampleSite2/hugo-gateway.toml
@@ -70,7 +70,12 @@ searchSectionsIndex = []
   version = "main"
   linkVersion = "main"
   url = "https://docs.solo.io/gloo-mesh-core/main/"
-  subversions = [ "v1", "v4" ]
+[[params.versions.subversions]]
+  id = "v1"
+  label = "Version 1"
+[[params.versions.subversions]]
+  id = "v4"
+  label = "Version 4"
 
 [[params.versions]]
   version = "2.5 (latest)"

--- a/exampleSite2/hugo-mesh-core.toml
+++ b/exampleSite2/hugo-mesh-core.toml
@@ -77,6 +77,7 @@ searchSectionsIndex = []
 [[params.versions.subversions]]
   id = "v4"
   label = "Classic"
+  dropdownDefault = true
 
 [[params.versions]]
   version = "2.5 (latest)"

--- a/exampleSite2/hugo-mesh-core.toml
+++ b/exampleSite2/hugo-mesh-core.toml
@@ -70,7 +70,12 @@ searchSectionsIndex = []
   version = "main"
   linkVersion = "main"
   url = "http://localhost:1313/main/v1/"
-  subversions = [ "v1", "v4" ]
+[[params.versions.subversions]]
+  id = "v1"
+  label = "K8s Gateway API"
+[[params.versions.subversions]]
+  id = "v4"
+  label = "Classic"
 
 [[params.versions]]
   version = "2.5 (latest)"

--- a/exampleSite2/hugo-mesh-core.toml
+++ b/exampleSite2/hugo-mesh-core.toml
@@ -68,6 +68,7 @@ searchSectionsIndex = []
 
 [[params.versions]]
   version = "main"
+  dropdown = "main"
   linkVersion = "main"
   url = "http://localhost:1313/main/v1/"
 [[params.versions.subversions]]
@@ -79,6 +80,7 @@ searchSectionsIndex = []
 
 [[params.versions]]
   version = "2.5 (latest)"
+  dropdown = "2.5 (latest)"
   linkVersion = "latest"
   url = "http://localhost:1313/latest/"
 

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -30,9 +30,9 @@
           var subversion = !!version && urlParts.find(function(part){ return !!versionsMap[version].includes(part); });
 
           var url = "{{ "" | relURL }}";
-          if(version) url += version+"/";
-          if(subversion) url += subversion+"/";
-          window.location.replace(url);
+          if(version) url += "/"+version;
+          if(subversion) url += "/"+subversion;
+          window.location.replace(url.replace('//', '/'));
         }, 1000)
       </script>
 {{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,6 +3,7 @@
         <div class="px-1">
             <h1 class="text-center">Page not found :(</h1>
             <h4 class="text-center">The page you are looking for doesn't exist or has been moved.</h4>
+            <h4 class="text-center">Redirecting to root...</h4>
         </div>
         <div class="px-1">            
             <a href="{{ "" | relURL }}"><i class="material-icons size-48 me-0">home</i></a>
@@ -11,7 +12,27 @@
       </div>
       <script>
         setTimeout(function(){
-          window.location.replace("{{ "" | relURL }}");
-        }, 2000)
+          var versionsMap = {};
+          {{ if .Site.Params.versions }}
+            {{ range .Site.Params.versions }}
+              {{ $version := .linkVersion }}
+              versionsMap["{{ $version }}"] = [];
+              {{ if .subversions }}
+                {{ range .subversions }}
+                versionsMap["{{ $version }}"].push("{{ .id }}");
+                {{ end }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+
+          var urlParts = window.location.pathname.split('/')
+          var version = urlParts.find(function(part){ return !!versionsMap[part] });
+          var subversion = !!version && urlParts.find(function(part){ return !!versionsMap[version].includes(part); });
+
+          var url = "{{ "" | relURL }}";
+          if(version) url += version+"/";
+          if(subversion) url += subversion+"/";
+          window.location.replace(url);
+        }, 1000)
       </script>
 {{ end }}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -8,5 +8,10 @@
             <a href="{{ "" | relURL }}"><i class="material-icons size-48 me-0">home</i></a>
             <!-- <a href="{{ "" | relURL }}"><i class="material-icons size-48 me-0">menu_book</i></a> -->
         </div>
-      </div>    
+      </div>
+      <script>
+        setTimeout(function(){
+          window.location.replace("{{ "" | relURL }}");
+        }, 2000)
+      </script>
 {{ end }}

--- a/layouts/partials/docs/footer/flexsearch.html
+++ b/layouts/partials/docs/footer/flexsearch.html
@@ -1,248 +1,248 @@
 <script type="module">
-    var suggestions = document.getElementById('suggestions');
-    var search = document.getElementById('flexsearch');
+  var suggestions = document.getElementById('suggestions');
+  var search = document.getElementById('flexsearch');
 
-    const flexsearchContainer = document.getElementById('FlexSearchCollapse');
+  const flexsearchContainer = document.getElementById('FlexSearchCollapse');
 
-    const hideFlexsearchBtn = document.getElementById('hideFlexsearch');
+  const hideFlexsearchBtn = document.getElementById('hideFlexsearch');
 
-    const configObject = { toggle: false }
-    const flexsearchContainerCollapse = new Collapse(flexsearchContainer, configObject) // initialized with no keyboard
+  const configObject = { toggle: false }
+  const flexsearchContainerCollapse = new Collapse(flexsearchContainer, configObject) // initialized with no keyboard
 
-    if (search !== null) {
-        document.addEventListener('keydown', inputFocus);
-        flexsearchContainer.addEventListener('shown.bs.collapse', function () {
-            search.focus();
-        });
-        // hide search collapse containder by clicking outside (except top header)
-        var topHeader = document.getElementById("top-header");
-        document.addEventListener('click', function(elem) {
-            if (!flexsearchContainer.contains(elem.target) && !topHeader.contains(elem.target))
-                flexsearchContainerCollapse.hide();
-        });
-    }
+  if (search !== null) {
+      document.addEventListener('keydown', inputFocus);
+      flexsearchContainer.addEventListener('shown.bs.collapse', function () {
+          search.focus();
+      });
+      // hide search collapse containder by clicking outside (except top header)
+      var topHeader = document.getElementById("top-header");
+      document.addEventListener('click', function(elem) {
+          if (!flexsearchContainer.contains(elem.target) && !topHeader.contains(elem.target))
+              flexsearchContainerCollapse.hide();
+      });
+  }
 
-    hideFlexsearchBtn.addEventListener('click', () =>{
-        flexsearchContainerCollapse.hide()
-    })
+  hideFlexsearchBtn.addEventListener('click', () =>{
+      flexsearchContainerCollapse.hide()
+  })
 
-    function inputFocus(e) {
-        if (e.ctrlKey && e.key === '/') {
-            e.preventDefault();
-            flexsearchContainerCollapse.toggle();
-        }
-        if (e.key === 'Escape' ) {
-            search.blur();
-            // suggestions.classList.add('d-none');
-            flexsearchContainerCollapse.hide();
-        }
-    };
+  function inputFocus(e) {
+      if (e.ctrlKey && e.key === '/') {
+          e.preventDefault();
+          flexsearchContainerCollapse.toggle();
+      }
+      if (e.key === 'Escape' ) {
+          search.blur();
+          // suggestions.classList.add('d-none');
+          flexsearchContainerCollapse.hide();
+      }
+  };
 
-    document.addEventListener('click', function(event) {
+  document.addEventListener('click', function(event) {
 
-    var isClickInsideElement = suggestions.contains(event.target);
+  var isClickInsideElement = suggestions.contains(event.target);
 
-    if (!isClickInsideElement) {
-        suggestions.classList.add('d-none');
-    }
+  if (!isClickInsideElement) {
+      suggestions.classList.add('d-none');
+  }
 
-    });
+  });
 
-    /*
-    Source:
-    - https://dev.to/shubhamprakash/trap-focus-using-javascript-6a3
-    */
+  /*
+  Source:
+  - https://dev.to/shubhamprakash/trap-focus-using-javascript-6a3
+  */
 
-    document.addEventListener('keydown',suggestionFocus);
+  document.addEventListener('keydown',suggestionFocus);
 
-    function suggestionFocus(e) {
-    const suggestionsHidden = suggestions.classList.contains('d-none');
-    if (suggestionsHidden) return;
+  function suggestionFocus(e) {
+  const suggestionsHidden = suggestions.classList.contains('d-none');
+  if (suggestionsHidden) return;
 
-    const focusableSuggestions= [...suggestions.querySelectorAll('a')];
-    if (focusableSuggestions.length === 0) return;
+  const focusableSuggestions= [...suggestions.querySelectorAll('a')];
+  if (focusableSuggestions.length === 0) return;
 
-    const index = focusableSuggestions.indexOf(document.activeElement);
+  const index = focusableSuggestions.indexOf(document.activeElement);
 
-    if (e.key === "ArrowUp") {
-        e.preventDefault();
-        const nextIndex = index > 0 ? index - 1 : 0;
-        focusableSuggestions[nextIndex].focus();
-    }
-    else if (e.key === "ArrowDown") {
-        e.preventDefault();
-        const nextIndex= index + 1 < focusableSuggestions.length ? index + 1 : index;
-        focusableSuggestions[nextIndex].focus();
-    }
+  if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const nextIndex = index > 0 ? index - 1 : 0;
+      focusableSuggestions[nextIndex].focus();
+  }
+  else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const nextIndex= index + 1 < focusableSuggestions.length ? index + 1 : index;
+      focusableSuggestions[nextIndex].focus();
+  }
 
-    }
+  }
 
-    /*
-    Source:
-    - https://github.com/nextapps-de/flexsearch#index-documents-field-search
-    - https://raw.githack.com/nextapps-de/flexsearch/master/demo/autocomplete.html
-    */
+  /*
+  Source:
+  - https://github.com/nextapps-de/flexsearch#index-documents-field-search
+  - https://raw.githack.com/nextapps-de/flexsearch/master/demo/autocomplete.html
+  */
 
-    (function(){
+  (function(){
 
-        var indexSectionMap = {};
-        function getIndex(section) {
-            if (!indexSectionMap[section]) {
-                indexSectionMap[section] = new FlexSearch.Document({
-                    // charset: "latin:default",
-                    tokenize: {{ .Site.Params.flexsearch.tokenize | default "forward" }},
-                    minlength: {{ .Site.Params.flexsearch.minQueryChar | default 0}},
-                    cache: {{ .Site.Params.flexsearch.cache | default 100 }},
-                    optimize: {{ .Site.Params.flexsearch.optimize | default true }},
-                    document: {
-                    id: 'id',
-                    store: [
-                        "href", "title", "description"
-                    ],
-                    index: ["title", "description", "content"]
-                    }
-                });
-            }
-            return indexSectionMap[section];
-        }
-
-
-    // Not yet supported: https://github.com/nextapps-de/flexsearch#complex-documents
+      var indexSectionMap = {};
+      function getIndex(section) {
+          if (!indexSectionMap[section]) {
+              indexSectionMap[section] = new FlexSearch.Document({
+                  // charset: "latin:default",
+                  tokenize: {{ .Site.Params.flexsearch.tokenize | default "forward" }},
+                  minlength: {{ .Site.Params.flexsearch.minQueryChar | default 0}},
+                  cache: {{ .Site.Params.flexsearch.cache | default 100 }},
+                  optimize: {{ .Site.Params.flexsearch.optimize | default true }},
+                  document: {
+                  id: 'id',
+                  store: [
+                      "href", "title", "description"
+                  ],
+                  index: ["title", "description", "content"]
+                  }
+              });
+          }
+          return indexSectionMap[section];
+      }
 
 
-    // var docs = [
-    //     {{ range $index, $page := (where .Site.Pages "Section" "docs") -}}
-    //     {
-    //         id: {{ $index }},
-    //         href: {{ .Permalink }},
-    //         title: {{ .Title }},
-    //         description: {{ .Params.description }},
-    //         content: {{ .Content }}
-    //     },
-    //     {{ end -}}
-    // ];
+  // Not yet supported: https://github.com/nextapps-de/flexsearch#complex-documents
 
 
-    // https://discourse.gohugo.io/t/range-length-or-last-element/3803/2
+  // var docs = [
+  //     {{ range $index, $page := (where .Site.Pages "Section" "docs") -}}
+  //     {
+  //         id: {{ $index }},
+  //         href: {{ .Permalink }},
+  //         title: {{ .Title }},
+  //         description: {{ .Params.description }},
+  //         content: {{ .Content }}
+  //     },
+  //     {{ end -}}
+  // ];
 
-    // {{ $list := slice }}
-    // {{- if and (isset .Site.Params.flexsearch "searchsectionsindex") (not (eq (len .Site.Params.flexsearch.searchSectionsIndex) 0)) }}
-    //     {{- if eq .Site.Params.docs.searchSectionsIndex "ALL" }}
-    //         {{- $list = .Site.Pages }}
-    //     {{- else }}
-    //         {{- $list = (where .Site.Pages "Type" "in" .Site.Params.flexsearch.searchSectionsIndex) }}
-    //     {{- if (in .Site.Params.flexsearch.searchSectionsIndex "HomePage") }}
-    //         {{ $list = $list | append .Site.Home }}
-    //     {{- end }}
-    //     {{- end }}
-    // {{- else }}
-    //     {{ $version := .Site.Params.version }}
-    //     {{- $list = (where .Site.Pages "Section" $version) }}
-    // {{- end }}
 
-    {{ $list := .Site.Pages }}
+  // https://discourse.gohugo.io/t/range-length-or-last-element/3803/2
 
-    {{ range $index, $element := $list -}}
-        {{ $subversion := or .Params.Params.subversion "" }}
-        {{ range .Ancestors -}}
-            {{ if .Params.Params.subversion }}
-                {{ $subversion = .Params.Params.subversion }}
-            {{ end }}
-        {{ end -}}
-        getIndex("{{ .Section }}-{{ $subversion }}").add(
-            {
-                id: {{ $index }},
-                href: "{{ .RelPermalink }}",
-                title: {{ .Title }},
-                {{ with .Description -}}
-                    description: {{ . }},
-                {{ else -}}
-                    description: {{ .Summary | htmlUnescape | plainify }},
-                {{ end -}}
-                content: ""
-            }
-        );
-    {{ end -}}
+  // {{ $list := slice }}
+  // {{- if and (isset .Site.Params.flexsearch "searchsectionsindex") (not (eq (len .Site.Params.flexsearch.searchSectionsIndex) 0)) }}
+  //     {{- if eq .Site.Params.docs.searchSectionsIndex "ALL" }}
+  //         {{- $list = .Site.Pages }}
+  //     {{- else }}
+  //         {{- $list = (where .Site.Pages "Type" "in" .Site.Params.flexsearch.searchSectionsIndex) }}
+  //     {{- if (in .Site.Params.flexsearch.searchSectionsIndex "HomePage") }}
+  //         {{ $list = $list | append .Site.Home }}
+  //     {{- end }}
+  //     {{- end }}
+  // {{- else }}
+  //     {{ $version := .Site.Params.version }}
+  //     {{- $list = (where .Site.Pages "Section" $version) }}
+  // {{- end }}
 
-    const versionSubversionMap = {};
-    {{ if .Site.Params.versions }}
-        {{ range .Site.Params.versions }}
-            {{ $version := .linkVersion }}
-            versionSubversionMap[{{$version}}] = [];
-            {{ if .subversions }}
-                {{ range .subversions }}
-                    versionSubversionMap[{{$version}}].push({{.}});
-                {{ end }}
-            {{ end }}
-        {{ end }}
-    {{ end }}
+  {{ $list := .Site.Pages }}
 
-    search.addEventListener('input', show_results, true);
+  {{ range $index, $element := $list -}}
+      {{ $subversion := or .Params.Params.subversion "" }}
+      {{ range .Ancestors -}}
+          {{ if .Params.Params.subversion }}
+              {{ $subversion = .Params.Params.subversion }}
+          {{ end }}
+      {{ end -}}
+      getIndex("{{ .Section }}-{{ $subversion }}").add(
+          {
+              id: {{ $index }},
+              href: "{{ .RelPermalink }}",
+              title: {{ .Title }},
+              {{ with .Description -}}
+                  description: {{ . }},
+              {{ else -}}
+                  description: {{ .Summary | htmlUnescape | plainify }},
+              {{ end -}}
+              content: ""
+          }
+      );
+  {{ end -}}
 
-    function show_results(){
-        const maxResult = {{ .Site.Params.flexsearch.maxResult | default 5}};
-        const minlength = {{ .Site.Params.flexsearch.minQueryChar | default 0}};
-        var searchQuery = this.value;
-        // There doesn't seem to be a perfect way to detect "Section" via JS, but
-        // this should work by finding any cases where something in url exists in search index key
-        const curSection = window.location.pathname.replace(/^\//, '').split('/')
-            .find(part=>!!versionSubversionMap[part]) || "{{ .Site.Params.version }}" || 'main';
-        const curSubversion = window.location.pathname.replace(/^\//, '').split('/')
-            .find(part=>!!versionSubversionMap[curSection].includes(part)) || "";
-        var index = getIndex(curSection+'-'+curSubversion);
-        var results = index.search(searchQuery, {limit: maxResult, enrich: true});
+  const versionSubversionMap = {};
+  {{ if .Site.Params.versions }}
+      {{ range .Site.Params.versions }}
+          {{ $version := .linkVersion }}
+          versionSubversionMap[{{$version}}] = [];
+          {{ if .subversions }}
+              {{ range .subversions }}
+                  versionSubversionMap[{{$version}}].push({{.id}});
+              {{ end }}
+          {{ end }}
+      {{ end }}
+  {{ end }}
 
-        // flatten results since index.search() returns results for each indexed field
-        const flatResults = new Map(); // keyed by href to dedupe results
-        for (const result of results.flatMap(r => r.result)) {
-        if (flatResults.has(result.doc.href)) continue;
-        flatResults.set(result.doc.href, result.doc);
-        }
+  search.addEventListener('input', show_results, true);
 
-        suggestions.innerHTML = "";
-        suggestions.classList.remove('d-none');
+  function show_results(){
+      const maxResult = {{ .Site.Params.flexsearch.maxResult | default 5}};
+      const minlength = {{ .Site.Params.flexsearch.minQueryChar | default 0}};
+      var searchQuery = this.value;
+      // There doesn't seem to be a perfect way to detect "Section" via JS, but
+      // this should work by finding any cases where something in url exists in search index key
+      const curSection = window.location.pathname.replace(/^\//, '').split('/')
+          .find(part=>!!versionSubversionMap[part]) || "{{ .Site.Params.version }}" || 'main';
+      const curSubversion = window.location.pathname.replace(/^\//, '').split('/')
+          .find(part=>!!versionSubversionMap[curSection].includes(part)) || "";
+      var index = getIndex(curSection+'-'+curSubversion);
+      var results = index.search(searchQuery, {limit: maxResult, enrich: true});
 
-        // inform user of search query minimum character requirement
-        if (searchQuery.length < minlength) {
-            const minCharMessage = document.createElement('div')
-            minCharMessage.innerHTML = `Please type at least <strong>${minlength}</strong> characters`
-            minCharMessage.classList.add("suggestion__no-results");
-            suggestions.appendChild(minCharMessage);
-            return;
-        } else {
-            // inform user that no results were found
-            if (flatResults.size === 0 && searchQuery) {
-                const noResultsMessage = document.createElement('div')
-                noResultsMessage.innerHTML = {{ i18n "search_no_results" | default "No results for" }} + ` "<strong>${searchQuery}</strong>"`
-                noResultsMessage.classList.add("suggestion__no-results");
-                suggestions.appendChild(noResultsMessage);
-                return;
-            }
-        }
+      // flatten results since index.search() returns results for each indexed field
+      const flatResults = new Map(); // keyed by href to dedupe results
+      for (const result of results.flatMap(r => r.result)) {
+      if (flatResults.has(result.doc.href)) continue;
+      flatResults.set(result.doc.href, result.doc);
+      }
 
-        // construct a list of suggestions
-        for(const [href, doc] of flatResults) {
-            const entry = document.createElement('div');
-            suggestions.appendChild(entry);
+      suggestions.innerHTML = "";
+      suggestions.classList.remove('d-none');
 
-            const a = document.createElement('a');
-            a.href = href;
-            entry.appendChild(a);
+      // inform user of search query minimum character requirement
+      if (searchQuery.length < minlength) {
+          const minCharMessage = document.createElement('div')
+          minCharMessage.innerHTML = `Please type at least <strong>${minlength}</strong> characters`
+          minCharMessage.classList.add("suggestion__no-results");
+          suggestions.appendChild(minCharMessage);
+          return;
+      } else {
+          // inform user that no results were found
+          if (flatResults.size === 0 && searchQuery) {
+              const noResultsMessage = document.createElement('div')
+              noResultsMessage.innerHTML = {{ i18n "search_no_results" | default "No results for" }} + ` "<strong>${searchQuery}</strong>"`
+              noResultsMessage.classList.add("suggestion__no-results");
+              suggestions.appendChild(noResultsMessage);
+              return;
+          }
+      }
 
-            const title = document.createElement('span');
-            title.textContent = doc.title;
-            title.classList.add("suggestion__title");
-            a.appendChild(title);
+      // construct a list of suggestions
+      for(const [href, doc] of flatResults) {
+          const entry = document.createElement('div');
+          suggestions.appendChild(entry);
 
-            const description = document.createElement('span');
-            description.textContent = doc.description;
-            description.classList.add("suggestion__description");
-            a.appendChild(description);
+          const a = document.createElement('a');
+          a.href = href;
+          entry.appendChild(a);
 
-            suggestions.appendChild(entry);
+          const title = document.createElement('span');
+          title.textContent = doc.title;
+          title.classList.add("suggestion__title");
+          a.appendChild(title);
 
-            if(suggestions.childElementCount == maxResult) break;
-        }
-    }
-    }());
+          const description = document.createElement('span');
+          description.textContent = doc.description;
+          description.classList.add("suggestion__description");
+          a.appendChild(description);
+
+          suggestions.appendChild(entry);
+
+          if(suggestions.childElementCount == maxResult) break;
+      }
+  }
+  }());
 </script>

--- a/layouts/partials/docs/navbar-version.html
+++ b/layouts/partials/docs/navbar-version.html
@@ -3,14 +3,20 @@
 {{ $newPath := strings.Replace $path $version "" -1 }}
 {{ $baseurl := .Site.BaseURL }}
 
+{{/* If current version uses a subversion, strip it from the path */}}
 {{ $versionTrimmed := trim $version "/" }}
 {{ $versionData := index (where .Site.Params.versions "linkVersion" $versionTrimmed) 0 }}
-
 {{ range $versionData.subversions }}
     {{ $newPath = strings.Replace $newPath .id "" 1 }}
 {{ end }}
 
 {{ $newPath = strings.TrimLeft "/" $newPath }}
 {{ range .Site.Params.versions }}
-    <li><a class="dropdown-item" href="{{ $baseurl }}/{{ .linkVersion }}/{{ $newPath }}">{{ .dropdown }}</a></li>
+    {{ $newSubversion := "" }}
+    {{ if .subversions }}
+        {{ $subObj := index (where .subversions "dropdownDefault" true) 0 }}
+        {{ if not $subObj }}{{ $subObj = index .subversions 0 }}{{ end }}
+        {{ $newSubversion = print "/" $subObj.id }}
+    {{ end }}
+    <li><a class="dropdown-item" href="{{ $baseurl }}/{{ .linkVersion }}{{ $newSubversion }}/{{ $newPath }}">{{ .dropdown }}</a></li>
 {{ end }}

--- a/layouts/partials/docs/navbar-version.html
+++ b/layouts/partials/docs/navbar-version.html
@@ -7,7 +7,7 @@
 {{ $versionData := index (where .Site.Params.versions "linkVersion" $versionTrimmed) 0 }}
 
 {{ range $versionData.subversions }}
-    {{ $newPath = strings.Replace $newPath . "" 1 }}
+    {{ $newPath = strings.Replace $newPath .id "" 1 }}
 {{ end }}
 
 {{ $newPath = strings.TrimLeft "/" $newPath }}

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -8,18 +8,21 @@
         </a>
     </div>
     <div class="sidebar-content" style="height: calc(100% - 131px);">
+        {{ $showSidebar := true }}
         {{ if .Site.Params.versions }}
             {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
             {{- $version := index $urlParts 1 -}}
             {{ $versionData := index (where .Site.Params.versions "linkVersion" $version) 0 }}
-            {{ if $versionData.subversions }}
+            {{ $showSidebar = and $versionData.subversions (index $urlParts 2) }}
+            {{ if and $versionData.subversions $showSidebar }}
                 {{- $subversion := index $urlParts 2 -}}
                 <div class="sidebar-subversion-btn-group">
                     {{ $newPath := delimit (after 3 $urlParts) "/" }}
                     {{ $baseurl := .Site.BaseURL }}
                     {{ range $versionData.subversions }}
                         {{ $active := eq $subversion .id }}
-                        <a class="btn btn-link btn-sm {{cond $active "btn-primary" "btn-soft"}}" href="{{ $baseurl }}/{{ $version }}/{{ .id }}/{{ $newPath }}">{{ .label }}</a>
+                        {{ $btnClass := cond $active "btn-primary" "btn-soft" }}
+                        <a class="btn btn-link btn-sm {{$btnClass}}" href="{{ $baseurl }}/{{ $version }}/{{ .id }}/{{ $newPath }}">{{ .label }}</a>
                     {{ end }}
                 </div>
             {{ end }}
@@ -29,6 +32,7 @@
             {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
             {{ $section := $currentPage.Section -}}
             {{ range (where .Site.Sections.ByWeight "Section" "in" $section) }}
+                {{ if not $showSidebar}} {{break}} {{ end }}
                 {{ $subversionToCheck := false }}
                 {{ if .Site.Params.versions }}
                     {{ $versionData := index (where .Site.Params.versions "linkVersion" .Section) 0 }}

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -13,7 +13,7 @@
             {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
             {{- $version := index $urlParts 1 -}}
             {{ $versionData := index (where .Site.Params.versions "linkVersion" $version) 0 }}
-            {{ $showSidebar = and $versionData.subversions (index $urlParts 2) }}
+            {{ $showSidebar = or (not $versionData.subversions) (index $urlParts 2) }}
             {{ if and $versionData.subversions $showSidebar }}
                 {{- $subversion := index $urlParts 2 -}}
                 <div class="sidebar-subversion-btn-group">

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -14,17 +14,13 @@
             {{ $versionData := index (where .Site.Params.versions "linkVersion" $version) 0 }}
             {{ if $versionData.subversions }}
                 {{- $subversion := index $urlParts 2 -}}
-                <div class="dropdown">
-                    <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        {{ $subversion }}
-                    </button>
-                    <ul class="dropdown-menu text-end">
-                        {{ $newPath := delimit (after 3 $urlParts) "/" }}
-                        {{ $baseurl := .Site.BaseURL }}
-                        {{ range $versionData.subversions }}
-                            <li><a class="dropdown-item" href="{{ $baseurl }}/{{ $version }}/{{ . }}/{{ $newPath }}">{{ . }}</a></li>
-                        {{ end }}
-                    </ul>
+                <div class="sidebar-subversion-btn-group">
+                    {{ $newPath := delimit (after 3 $urlParts) "/" }}
+                    {{ $baseurl := .Site.BaseURL }}
+                    {{ range $versionData.subversions }}
+                        {{ $active := eq $subversion .id }}
+                        <a class="btn btn-link btn-sm {{cond $active "btn-primary" "btn-soft"}}" href="{{ $baseurl }}/{{ $version }}/{{ .id }}/{{ $newPath }}">{{ .label }}</a>
+                    {{ end }}
                 </div>
             {{ end }}
         {{ end }}
@@ -38,7 +34,7 @@
                     {{ $versionData := index (where .Site.Params.versions "linkVersion" .Section) 0 }}
                     {{ if and $versionData $versionData.subversions }}
                         {{ range $urlParts }}
-                            {{ if in $versionData.subversions . }}
+                            {{ if (where $versionData.subversions "id" "eq" .) | len }}
                                 {{ $subversionToCheck = . }}
                             {{ end }}
                         {{ end }}


### PR DESCRIPTION
### Changes

![image](https://github.com/solo-io/docs-theme-lotus/assets/87029548/acfc4966-07ce-45af-96ae-bb5fc9d8d49c)

This also makes a change that now requires the `subversions` string list to now be an array of id/label strings
![image](https://github.com/solo-io/docs-theme-lotus/assets/87029548/0cbbeaba-9d90-4900-af4a-6bae40828fca)


<!-- ### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [x] This change does not need a documentation update -->

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
