### PR TITLE
Version banner

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -52,6 +52,11 @@
                                             {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "banner.html") . -}}
                                             </div>
                                             {{ end }}
+                                            {{ if site.Params.versionBanner | default false }}
+                                            <div class="banner">
+                                            {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "versionbanner.html") . -}}
+                                            </div>
+                                            {{ end }}
                                             <div class="mb-0 d-flex">
                                                 {{ if site.Params.docs.titleIcon | default false }}
                                                 <i class="material-icons title-icon me-2">{{- .Params.icon | default "article" }}</i>

--- a/layouts/partials/docs/versionbanner.html
+++ b/layouts/partials/docs/versionbanner.html
@@ -1,0 +1,15 @@
+{{- $path := .Page.RelPermalink -}}
+{{ $version := .Page.FirstSection.RelPermalink }}
+{{ $newPath := strings.Replace $path $version "" -1 }}
+{{ $baseurl := .Site.BaseURL }}
+
+{{/* If current version uses a subversion, strip it from the path */}}
+{{ $versionTrimmed := trim $version "/" }}
+{{ if eq $versionTrimmed "main" }}
+<div class="alert alert-info d-flex">
+    <div class="w-100">
+     <p>{{ .Site.Params.versionBannerText | markdownify }}</p>
+    </div>
+ </div>
+ {{ end }}
+ 


### PR DESCRIPTION
### Changes

Allows to add a version banner to the main version of the docs. See request from Shane in [Slack](https://solo-io-corp.slack.com/archives/CHJV572TG/p1731419353403789).

To activate the banner, put the following into the toml file: 

```toml
[params]
versionBanner = true
versionBannerText = "This version of the documentation is currently _under development_. To view the documentation for the **latest stable** version, click [**here**](https://docs.solo.io/gateway/latest). " 
```

Updated our [Versioning Slab doc](https://soloio.slab.com/posts/versioning-rqad3xdi) to include a brief pointer on this.
