### PR TITLE
Mermaid diagram light mode

### DIFF
--- a/assets/docs/scss/custom/components/_backgrounds.scss
+++ b/assets/docs/scss/custom/components/_backgrounds.scss
@@ -4,12 +4,14 @@
 
 :root {
     --bg-default: hsl(var(--primary-800-hsl),0.1);
+    --bg-mermaid: var(--gray-100);
     --bg-default-border: hsl(var(--primary-800-hsl),0.1);
     --bg-default-color: var(--text-default);
 }
 
 [data-dark-mode] {
     --bg-default: var(--gray-800);
+    --bg-mermaid: var(--gray-800);
     --bg-default-border: hsl(var(--primary-200-hsl),0.1);
     --bg-default-color: var(--text-default);
 }

--- a/assets/docs/scss/custom/plugins/mermaid/_mermaid.scss
+++ b/assets/docs/scss/custom/plugins/mermaid/_mermaid.scss
@@ -37,5 +37,12 @@
         text {
             fill: var(--text-default) !important;
         }
+        #sequencenumber circle {
+            fill: var(--bg-default) !important;
+            stroke: var(--text-default) !important;
+        }
+        .sequenceNumber {
+            fill: var(--text-default) !important;
+        }
     }
 }

--- a/assets/docs/scss/custom/plugins/mermaid/_mermaid.scss
+++ b/assets/docs/scss/custom/plugins/mermaid/_mermaid.scss
@@ -38,7 +38,7 @@
             fill: var(--text-default) !important;
         }
         #sequencenumber circle {
-            fill: var(--bg-default) !important;
+            fill: var(--bg-mermaid) !important;
             stroke: var(--text-default) !important;
         }
         .sequenceNumber {


### PR DESCRIPTION
Followup to https://github.com/solo-io/docs-theme-lotus/pull/35/

Light mode autonumber circles were too dark to read.

### Example too dark
<img width="965" alt="image" src="https://github.com/user-attachments/assets/ea41263c-8420-4e68-9ea9-bb6f712e0a5a" />


### Now with the fix
<img width="904" alt="image" src="https://github.com/user-attachments/assets/16871e9c-a3ca-4285-bc66-8849d3e41399" />

<img width="899" alt="image" src="https://github.com/user-attachments/assets/afdca1d9-6419-484c-9b03-63b25782e166" />
