### PR TITLE
Enterprise tag

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -66,6 +66,9 @@
                                                     {{ if .Draft }}
                                                         <span class="badge bg-default fs-6 mb-1 align-middle">DRAFT</span>
                                                     {{ end }}
+                                                    {{ if $currentPage.Params.Enterprise }}
+                                                        <span class="badge bg-default fs-6 mb-1 align-middle">ENTERPRISE</span>
+                                                    {{ end }}
                                                 </h1>
                                             </div>
                                             {{ if site.Params.docs.descriptions | default false }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,6 +8,7 @@
                     <span class="h1 icon-color">
                         <i class="material-icons align-middle">{{- .Params.icon | default "article" }}</i>
                         {{ if .Draft }}<span class="badge bg-default fs-6 align-middle">DRAFT</span>{{ end }}
+                        {{ if .Page.Params.Enterprise }}<span class="badge bg-default fs-6 align-middle">Enterprise</span>{{ end }}
                     </span>
                     <div class="card-body p-0 content">
                         <p class="fs-5 fw-semibold card-title mb-1">{{ .Title }}</p>


### PR DESCRIPTION
### Changes

This change enables us to set an `enterprise: true` entry in the frontmatter of a page to create an enterprise tag on the page. 

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/db3ee9b9-b0c9-4f9b-9c8c-07c1fc0d499e" />

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
