### PR TITLE
Tags

### DIFF
--- a/assets/docs/scss/_variables.scss
+++ b/assets/docs/scss/_variables.scss
@@ -343,6 +343,10 @@ $stretched-link-z-index:                  1;
 
     // lightness variables
     --l-100: 100%;
+    
+    // Badge
+    --badge-primary-bg: var(--primary);
+    --badge-primary-color: var(--primary-200);
 
     // Buttons
     --btn-soft-color: var(--primary);
@@ -396,6 +400,10 @@ $stretched-link-z-index:                  1;
     --text-default-inv: var(--text-dark);
     --text-muted: #b6b9be;
     --#{$prefix}secondary-color: #6c757d;
+    
+    // Badge
+    --badge-primary-bg: var(--primary);
+    --badge-primary-color: var(--primary-200);
 
     // Buttons
     --btn-soft-color: var(--gray-400);

--- a/assets/docs/scss/custom/components/_backgrounds.scss
+++ b/assets/docs/scss/custom/components/_backgrounds.scss
@@ -27,6 +27,13 @@
     border: 1px solid var(--btn-primary-border) !important;
     color: var(--btn-primary-color) !important;
 }
+
+.bg-tag {
+    background-color: var(--badge-primary-bg) !important;
+    border: 1px solid var(--btn-primary-border) !important;
+    color: var(--white) !important;
+}
+
 // .bg-light {
 //     background-color: rgba($value, 0.1) !important;
 //     border: 1px solid rgba($value, 0.1) !important;

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -69,6 +69,9 @@
                                                     {{ if $currentPage.Params.Enterprise }}
                                                         <span class="badge bg-default fs-6 mb-1 align-middle">ENTERPRISE</span>
                                                     {{ end }}
+                                                    {{ if $currentPage.Params.Oss }}
+                                                        <span class="badge bg-default fs-6 mb-1 align-middle">OPEN SOURCE</span>
+                                                    {{ end }}
                                                 </h1>
                                             </div>
                                             {{ if site.Params.docs.descriptions | default false }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -72,6 +72,15 @@
                                                     {{ if $currentPage.Params.Oss }}
                                                         <span class="badge bg-default fs-6 mb-1 align-middle">OPEN SOURCE</span>
                                                     {{ end }}
+                                                    {{ if $currentPage.Params.Alpha }}
+                                                        <span class="badge bg-tag fs-6 mb-1 align-middle">ALPHA</span>
+                                                    {{ end }}
+                                                    {{ if $currentPage.Params.Beta }}
+                                                        <span class="badge bg-tag fs-6 mb-1 align-middle">BETA</span>
+                                                    {{ end }}
+                                                    {{ if $currentPage.Params.Experimental }}
+                                                        <span class="badge bg-tag fs-6 mb-1 align-middle">EXPERIMENTAL</span>
+                                                    {{ end }}
                                                 </h1>
                                             </div>
                                             {{ if site.Params.docs.descriptions | default false }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -9,6 +9,7 @@
                         <i class="material-icons align-middle">{{- .Params.icon | default "article" }}</i>
                         {{ if .Draft }}<span class="badge bg-default fs-6 align-middle">DRAFT</span>{{ end }}
                         {{ if .Page.Params.Enterprise }}<span class="badge bg-default fs-6 align-middle">Enterprise</span>{{ end }}
+                        {{ if .Page.Params.Oss }}<span class="badge bg-default fs-6 align-middle">Open Source</span>{{ end }}
                     </span>
                     <div class="card-body p-0 content">
                         <p class="fs-5 fw-semibold card-title mb-1">{{ .Title }}</p>

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -10,6 +10,9 @@
                         {{ if .Draft }}<span class="badge bg-default fs-6 align-middle">DRAFT</span>{{ end }}
                         {{ if .Page.Params.Enterprise }}<span class="badge bg-default fs-6 align-middle">Enterprise</span>{{ end }}
                         {{ if .Page.Params.Oss }}<span class="badge bg-default fs-6 align-middle">Open Source</span>{{ end }}
+                        {{ if .Page.Params.Alpha }}<span class="badge bg-tag fs-6 align-middle">Alpha</span>{{ end }}
+                        {{ if .Page.Params.Beta }}<span class="badge bg-tag fs-6 align-middle">Beta</span>{{ end }}
+                        {{ if .Page.Params.Experimental }}<span class="badge bg-tag fs-6 align-middle">Experimental</span>{{ end }}
                     </span>
                     <div class="card-body p-0 content">
                         <p class="fs-5 fw-semibold card-title mb-1">{{ .Title }}</p>

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -81,7 +81,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{- .Params.icon | default "notes" }}</i>
                                 {{ end }}
-                                {{- .Title }}
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </button>
                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                 <ul>
@@ -94,7 +94,7 @@
                                                     {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                         <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                     {{ end }}
-                                                    {{- .Title }}
+                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                 </button>
                                                 <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                     <ul>
@@ -107,7 +107,7 @@
                                                                         {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                             <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                         {{ end }}
-                                                                        {{- .Title }}
+                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                     </button>
                                                                     <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                         <ul>
@@ -120,7 +120,7 @@
                                                                                             {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                 <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                             {{ end }}
-                                                                                            {{- .Title }}
+                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                         </button>
                                                                                         <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                             <ul>
@@ -133,7 +133,7 @@
                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                 {{ end }}
-                                                                                                                {{- .Title }}
+                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                             </button>
                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                             <ul>
@@ -146,21 +146,21 @@
                                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                                 {{ end }}
-                                                                                                                                {{- .Title }}
+                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                                             </button>
                                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                                                 <ul>
                                                                                                                                     {{ range .Pages }}
                                                                                                                                     {{ if not .Params.hidden }}
                                                                                                                                         {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}">{{ .Title }}</a></li>
+                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                                     {{ end }}
                                                                                                                                     {{ end }}
                                                                                                                                 </ul>
                                                                                                                             </div>
                                                                                                                         </li>
                                                                                                                     {{ else }}
-                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}">{{ .Title }}</a></li>
+                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-0 py-0" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                     {{ end }}
                                                                                                                     {{ end }}
                                                                                                                 {{ end }}
@@ -168,7 +168,7 @@
                                                                                                         </div>
                                                                                                     </li>
                                                                                                 {{ else }}
-                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}">{{ .Title }}</a></li>
+                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                 {{ end }}
                                                                                                 {{ end }}
                                                                                             {{ end }}
@@ -176,7 +176,7 @@
                                                                                         </div>
                                                                                     </li>
                                                                                 {{ else }}
-                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}">{{ .Title }}</a></li>
+                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                 {{ end }}
                                                                                 {{ end }}
                                                                             {{ end }}
@@ -184,7 +184,7 @@
                                                                     </div>
                                                                 </li>
                                                             {{ else }}
-                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}">{{ .Title }}</a></li>
+                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                             {{ end }}
                                                             {{ end }}
                                                         {{ end }}
@@ -192,7 +192,7 @@
                                                 </div>
                                             </li>
                                         {{ else }}
-                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}">{{ .Title }}</a></li>
+                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                         {{ end }}
                                     {{ end }}
                                     {{ end }}
@@ -206,7 +206,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{ .Params.icon }}</i>
                                 {{ end }}
-                                {{ .Title }}
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </a>
                         </li>
                     {{ end }}


### PR DESCRIPTION
### Changes

Adds the capability of adding maturity level tags to a page. Currently supported values are alpha, beta, experimental. To enable and display the tag for a page, add the following values to the front matter: 
```
alpha: true
beta: true
experimental: true
```

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/b47617d9-f26f-44be-9948-ca1356a215ec" />

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/0704f413-c5da-401a-9797-25236ac405a9" />


You can also add enterprise or open source tags (see screenshots above) with 
```
enterprise: true
oss: true
```

Enterprise tagged pages will also have an enterprise tag in the sidebar

<img width="564" alt="image" src="https://github.com/user-attachments/assets/a73c6339-3858-456a-b42b-f7fdb0430bc6" />

<img width="575" alt="image" src="https://github.com/user-attachments/assets/3a022eda-91d8-4d1c-bfd2-9f61875c14e3" />

