### PR TITLE
Add capability to disable autogenerated cards

### DIFF
--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,30 +1,33 @@
 {{ define "main" }}
+  {{ if not .Params.disableCards }}
     <div class="row flex-xl-wrap">
-        {{ range .Pages.ByWeight }}
+      {{ range .Pages.ByWeight }}
         {{ if not .Params.hidden }}
-        <div id="list-item" class="col-md-4 col-12 mt-4 pt-2">
+          <div id="list-item" class="col-md-4 col-12 mt-4 pt-2">
             <a class="text-decoration-none text-reset" href="{{ .Permalink }}">
-                <div class="card h-100 features feature-full-bg rounded p-4 position-relative overflow-hidden border-1">
-                    <span class="h1 icon-color">
-                        <i class="material-icons align-middle">{{- .Params.icon | default "article" }}</i>
-                        {{ if .Draft }}<span class="badge bg-default fs-6 align-middle">DRAFT</span>{{ end }}
-                        {{ if .Page.Params.Enterprise }}<span class="badge bg-default fs-6 align-middle">Enterprise</span>{{ end }}
-                        {{ if .Page.Params.Oss }}<span class="badge bg-default fs-6 align-middle">Open Source</span>{{ end }}
-                        {{ if .Page.Params.Alpha }}<span class="badge bg-tag fs-6 align-middle">Alpha</span>{{ end }}
-                        {{ if .Page.Params.Beta }}<span class="badge bg-tag fs-6 align-middle">Beta</span>{{ end }}
-                        {{ if .Page.Params.Experimental }}<span class="badge bg-tag fs-6 align-middle">Experimental</span>{{ end }}
-                    </span>
-                    <div class="card-body p-0 content">
-                        <p class="fs-5 fw-semibold card-title mb-1">{{ .Title }}</p>
-                        <p class="para card-text mb-0">{{ .Description | truncate (.Site.Params.docs.listDescTrunc | default 100) | markdownify }}</p>
-                    </div>
-                    <!-- <div class="position-absolute top-0 end-0">
-                        <i class="material-icons opacity-05">{{- .Params.icon }}</i>
-                    </div> -->
+              <div class="card h-100 features feature-full-bg rounded p-4 position-relative overflow-hidden border-1">
+                <span class="h1 icon-color">
+                  <i class="material-icons align-middle">{{ .Params.icon | default "article" }}</i>
+                  {{ if .Draft }}<span class="badge bg-default fs-6 align-middle">DRAFT</span>{{ end }}
+                  {{ if .Params.Enterprise }}<span class="badge bg-default fs-6 align-middle">Enterprise</span>{{ end }}
+                  {{ if .Params.Oss }}<span class="badge bg-default fs-6 align-middle">Open Source</span>{{ end }}
+                  {{ if .Params.Alpha }}<span class="badge bg-tag fs-6 align-middle">Alpha</span>{{ end }}
+                  {{ if .Params.Beta }}<span class="badge bg-tag fs-6 align-middle">Beta</span>{{ end }}
+                  {{ if .Params.Experimental }}<span class="badge bg-tag fs-6 align-middle">Experimental</span>{{ end }}
+                </span>
+                <div class="card-body p-0 content">
+                  <p class="fs-5 fw-semibold card-title mb-1">{{ .Title }}</p>
+                  <p class="para card-text mb-0">{{ .Description | truncate (.Site.Params.docs.listDescTrunc | default 100) | markdownify }}</p>
                 </div>
+              </div>
             </a>
-        </div><!--end col-->
+          </div><!--end col-->
         {{ end }}
-        {{ end }}
+      {{ end }}
     </div>
+  {{ else }}
+    <div class="content">
+      {{ .Content }}
+    </div>
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
### Changes

By adding `disableCards: true` to the front matter of an index page, you can now disable the auto-generated cards and instead display whatever is on the index page. This way, we can introduce custom index pages. 

Example: 
```
---
title: Gloo Gateway (Kubernetes Gateway API)
weight: 1
description: Welcome to the Gloo Gateway (Kubernetes Gateway API) documentation.
cascade:
  - type: "docs"
disableCards: true
---


We have two versions

{{< cards >}}
{{< card title="1.18.x" description="Latest version of the v1 API" link="/1.18.x" icon="open_in_new" >}}
{{< card title="2.0.x" description="Latest version of the v2 API" link="/2.0" icon="open_in_new" >}}
{{< /cards >}}
```

will result in 

<img width="1389" alt="image" src="https://github.com/user-attachments/assets/99336a63-3b86-4169-a0fe-9e6fd489136c" />
