### PR TITLE
Allow enterprise tag on page, but not nav

### DIFF
--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -81,7 +81,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{- .Params.icon | default "notes" }}</i>
                                 {{ end }}
-                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </button>
                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                 <ul>
@@ -94,7 +94,7 @@
                                                     {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                         <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                     {{ end }}
-                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                 </button>
                                                 <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                     <ul>
@@ -107,7 +107,7 @@
                                                                         {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                             <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                         {{ end }}
-                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                     </button>
                                                                     <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                         <ul>
@@ -120,7 +120,7 @@
                                                                                             {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                 <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                             {{ end }}
-                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                         </button>
                                                                                         <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                             <ul>
@@ -133,7 +133,7 @@
                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                 {{ end }}
-                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                             </button>
                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                             <ul>
@@ -146,21 +146,21 @@
                                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                                 {{ end }}
-                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                                             </button>
                                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                                                 <ul>
                                                                                                                                     {{ range .Pages }}
                                                                                                                                     {{ if not .Params.hidden }}
                                                                                                                                         {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                                     {{ end }}
                                                                                                                                     {{ end }}
                                                                                                                                 </ul>
                                                                                                                             </div>
                                                                                                                         </li>
                                                                                                                     {{ else }}
-                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-0 py-0" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-0 py-0" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                     {{ end }}
                                                                                                                     {{ end }}
                                                                                                                 {{ end }}
@@ -168,7 +168,7 @@
                                                                                                         </div>
                                                                                                     </li>
                                                                                                 {{ else }}
-                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                 {{ end }}
                                                                                                 {{ end }}
                                                                                             {{ end }}
@@ -176,7 +176,7 @@
                                                                                         </div>
                                                                                     </li>
                                                                                 {{ else }}
-                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                 {{ end }}
                                                                                 {{ end }}
                                                                             {{ end }}
@@ -184,7 +184,7 @@
                                                                     </div>
                                                                 </li>
                                                             {{ else }}
-                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                             {{ end }}
                                                             {{ end }}
                                                         {{ end }}
@@ -192,7 +192,7 @@
                                                 </div>
                                             </li>
                                         {{ else }}
-                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                         {{ end }}
                                     {{ end }}
                                     {{ end }}
@@ -206,7 +206,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{ .Params.icon }}</i>
                                 {{ end }}
-                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </a>
                         </li>
                     {{ end }}

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -81,7 +81,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{- .Params.icon | default "notes" }}</i>
                                 {{ end }}
-                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </button>
                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                 <ul>
@@ -94,7 +94,7 @@
                                                     {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                         <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                     {{ end }}
-                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                 </button>
                                                 <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                     <ul>
@@ -107,7 +107,7 @@
                                                                         {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                             <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                         {{ end }}
-                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                     </button>
                                                                     <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                         <ul>
@@ -120,7 +120,7 @@
                                                                                             {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                 <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                             {{ end }}
-                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                         </button>
                                                                                         <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                             <ul>
@@ -133,7 +133,7 @@
                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                 {{ end }}
-                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                             </button>
                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                             <ul>
@@ -146,21 +146,21 @@
                                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                                 {{ end }}
-                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                                             </button>
                                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                                                 <ul>
                                                                                                                                     {{ range .Pages }}
                                                                                                                                     {{ if not .Params.hidden }}
                                                                                                                                         {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                                     {{ end }}
                                                                                                                                     {{ end }}
                                                                                                                                 </ul>
                                                                                                                             </div>
                                                                                                                         </li>
                                                                                                                     {{ else }}
-                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-0 py-0" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-0 py-0" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                     {{ end }}
                                                                                                                     {{ end }}
                                                                                                                 {{ end }}
@@ -168,7 +168,7 @@
                                                                                                         </div>
                                                                                                     </li>
                                                                                                 {{ else }}
-                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                 {{ end }}
                                                                                                 {{ end }}
                                                                                             {{ end }}
@@ -176,7 +176,7 @@
                                                                                         </div>
                                                                                     </li>
                                                                                 {{ else }}
-                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                 {{ end }}
                                                                                 {{ end }}
                                                                             {{ end }}
@@ -184,7 +184,7 @@
                                                                     </div>
                                                                 </li>
                                                             {{ else }}
-                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                             {{ end }}
                                                             {{ end }}
                                                         {{ end }}
@@ -192,7 +192,7 @@
                                                 </div>
                                             </li>
                                         {{ else }}
-                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                         {{ end }}
                                     {{ end }}
                                     {{ end }}
@@ -206,7 +206,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{ .Params.icon }}</i>
                                 {{ end }}
-                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if .Params.enterprise }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise .Params.enterpriseSidebar }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </a>
                         </li>
                     {{ end }}


### PR DESCRIPTION
### Changes

This change allows an enterprise tag to show up on a page, but not in the nav. By default, the enterprise tag will show in the nav. You have to explicitly disable that to now show it. 

Example: 
If the front matter looks like this (default behavior)
```
---
title: Basic retries
weight: 5
description: Configure basic retries on the HTTPRoute.
enterprise: true
---
```

It will show the enterprise tag on the page and in the sidebar
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/450f62aa-d0c7-4e29-9db6-8eca2fa0c4cc" />


If the front matter includes `excludeEnterpriseFromSidebar: true`, the enterprise tag will not show in the sidebar. but it will continue to show on the page

```
---
title: Basic retries
weight: 5
description: Configure basic retries on the HTTPRoute.
enterprise: true
excludeEnterpriseFromSidebar: true
---
```

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/11ab2af3-5877-421a-92c1-0af9dab6e2fe" />



Below you'll find a checklist. For each item on the list, check one option and delete the other.

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [x] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI
