### PR TITLE
Add space between title and enterprise tag

### DIFF
--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -81,7 +81,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{- .Params.icon | default "notes" }}</i>
                                 {{ end }}
-                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </button>
                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                 <ul>
@@ -94,7 +94,7 @@
                                                     {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                         <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                     {{ end }}
-                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                    <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                 </button>
                                                 <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                     <ul>
@@ -107,7 +107,7 @@
                                                                         {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                             <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                         {{ end }}
-                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                        <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                     </button>
                                                                     <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                         <ul>
@@ -120,7 +120,7 @@
                                                                                             {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                 <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                             {{ end }}
-                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                            <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                         </button>
                                                                                         <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                             <ul>
@@ -133,7 +133,7 @@
                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                 {{ end }}
-                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                             </button>
                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                             <ul>
@@ -146,14 +146,14 @@
                                                                                                                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                                                                                                                     <!-- <span class="material-icons me-2">{{- .Params.icon }}</span> -->
                                                                                                                                 {{ end }}
-                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                                                                                                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                                                                                                                             </button>
                                                                                                                             <div class="sidebar-submenu {{ if $active }}d-block{{ end }}">
                                                                                                                                 <ul>
                                                                                                                                     {{ range .Pages }}
                                                                                                                                     {{ if not .Params.hidden }}
                                                                                                                                         {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                                                        <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                                                     {{ end }}
                                                                                                                                     {{ end }}
                                                                                                                                 </ul>
@@ -168,7 +168,7 @@
                                                                                                         </div>
                                                                                                     </li>
                                                                                                 {{ else }}
-                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                                 {{ end }}
                                                                                                 {{ end }}
                                                                                             {{ end }}
@@ -176,7 +176,7 @@
                                                                                         </div>
                                                                                     </li>
                                                                                 {{ else }}
-                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                                    <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                                                 {{ end }}
                                                                                 {{ end }}
                                                                             {{ end }}
@@ -184,7 +184,7 @@
                                                                     </div>
                                                                 </li>
                                                             {{ else }}
-                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                                                <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                                             {{ end }}
                                                             {{ end }}
                                                         {{ end }}
@@ -192,7 +192,7 @@
                                                 </div>
                                             </li>
                                         {{ else }}
-                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
+                                            <li class="{{ if $active }}current{{ end }} {{ if eq .Site.Params.docs.sidebarIcons true -}}{{ else }}no-icon{{ end }}"><a class="sidebar-nested-link" href="{{ .Permalink }}"><span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span></a></li>
                                         {{ end }}
                                     {{ end }}
                                     {{ end }}
@@ -206,7 +206,7 @@
                                 {{ if eq .Site.Params.docs.sidebarIcons true -}}
                                     <i class="material-icons me-2">{{ .Params.icon }}</i>
                                 {{ end }}
-                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} <span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
+                                <span class="d-inline-flex align-items-center">{{ .Title }}{{ if and .Params.enterprise (not .Params.excludeEnterpriseFromSidebar) }} &nbsp;<span class="badge bg-default align-middle px-1 py-1" style="font-size: 0.65rem;" title="Enterprise only">ENTERPRISE</span>{{ end }}</span>
                             </a>
                         </li>
                     {{ end }}


### PR DESCRIPTION
### Changes

Please describe the changes made in the pull request here.

Below you'll find a checklist. For each item on the list, check one option and delete the other.

<!-- ### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [ ] This PR does not make a user-facing change -->

<!-- ### Documentation
- [ ] [Docs](https://github.com/colinwilson/lotusdocs.dev) have been updated
- [ ] This change does not need a documentation update -->

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [ ] This PR does not change the UI


New: 
<img width="373" height="522" alt="image" src="https://github.com/user-attachments/assets/30b30bb7-0fee-4460-8ffc-935e357eb880" />


Old: 
<img width="402" height="505" alt="image" src="https://github.com/user-attachments/assets/7304ccc9-7e1f-490c-ba5d-7dd9b1d14d1f" />


