### PR TITLE
Version specific banner

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -57,6 +57,11 @@
                                             {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "versionbanner.html") . -}}
                                             </div>
                                             {{ end }}
+                                            {{ if site.Params.versionSpecificBanner | default false }}
+                                            <div class="banner">
+                                            {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "versionspecificbanner.html") . -}}
+                                            </div>
+                                            {{ end }}
                                             {{ $version := .Page.FirstSection.RelPermalink }}
                                             {{ $versionTrimmed := trim $version "/" }}
                                             {{ range site.Params.versions }}                                

--- a/layouts/partials/docs/versionspecificbanner.html
+++ b/layouts/partials/docs/versionspecificbanner.html
@@ -1,0 +1,15 @@
+{{- $path := trim .Page.RelPermalink "/" -}}
+{{ $parts := split $path "/" }}
+{{ $version := index $parts 0 }}
+
+{{ range .Site.Params.versions }}
+  {{ if eq .version $version }} 
+   {{ if ne .banner "" }}
+   <div class="alert alert-info d-flex">
+       <div class="w-100">
+        <p>{{ .banner | markdownify }}</p>
+       </div>
+    </div>
+ {{ end }}
+ {{ end }}
+{{ end }}


### PR DESCRIPTION
### Changes

Add the capability to show a version specific banner 

To enable this feature, add the following to the toml file: 

```
[params]
versionSpecificBanner = true


[[params.versions]]
  version = "2.1.x"
  dropdown = ""
  linkVersion = "2.1.x"
  url = "https://docs.solo.io/gateway/2.1.x"
  banner = "This version of the documentation is currently under development. Select **2.0.x** from the version drop down or go to the [landing page](https://docs.solo.io/gateway/2.0.x) of the latest stable version."

[[params.versions]]
  version = "2.0.x"
  dropdown = "2.0.x (latest)"
  linkVersion = "2.0.x"
  url = "https://docs.solo.io/gateway/2.0.x"
  banner = ""
  
[[params.versions]]
  version = "1.21.x"
  dropdown = ""
  linkVersion = "1.21.x"
  url = "https://docs.solo.io/gateway/1.21.x"
  banner = "If you are interested in trying out Gloo Gateway with the Kubernetes Gateway API, check out [Gloo Gateway version 2.0.x](https://docs.solo.io/gateway/2.0.x/). This version adds enterprise functionality on top of the kgateway open source project."

[[params.versions]]
  version = "1.20.x"
  dropdown = "1.20.x "
  linkVersion = "1.20.x"
  url = "https://docs.solo.io/gateway/1.20.x" 
  banner = "If you are interested in trying out Gloo Gateway with the Kubernetes Gateway API, check out [Gloo Gateway version 2.0.x](https://docs.solo.io/gateway/2.0.x/). This version adds enterprise functionality on top of the kgateway open source project."

[[params.versions]]
  version = "1.19.x"
  dropdown = "1.19.x"
  linkVersion = "1.19.x"
  url = "https://docs.solo.io/gateway/1.19.x"
  banner = "If you are interested in trying out Gloo Gateway with the Kubernetes Gateway API, check out [Gloo Gateway version 2.0.x](https://docs.solo.io/gateway/2.0.x/). This version adds enterprise functionality on top of the kgateway open source project."

[[params.versions]]
  version = "1.18.x"
  dropdown = "1.18.x"
  linkVersion = "1.18.x"
  url = "https://docs.solo.io/gateway/1.18.x"
  banner = "If you are interested in trying out Gloo Gateway with the Kubernetes Gateway API, check out [Gloo Gateway version 2.0.x](https://docs.solo.io/gateway/2.0.x/). This version adds enterprise functionality on top of the kgateway open source project."

[[params.versions]]
  version = "1.17.x"
  dropdown = "1.17.x"
  linkVersion = "1.17.x"
  url = "https://docs.solo.io/gateway/1.17.x"
  banner = "If you are interested in trying out Gloo Gateway with the Kubernetes Gateway API, check out [Gloo Gateway version 2.0.x](https://docs.solo.io/gateway/2.0.x/). This version adds enterprise functionality on top of the kgateway open source project."
```

<img width="1703" height="447" alt="image" src="https://github.com/user-attachments/assets/96dd80da-372f-43ea-a225-66f7db5879b1" />
<img width="1711" height="287" alt="image" src="https://github.com/user-attachments/assets/d8d51081-cee7-4ccb-979e-4791ad5b8856" />
