### PR TITLE
Add product versions

### DIFF
--- a/layouts/partials/docs/navbar-version.html
+++ b/layouts/partials/docs/navbar-version.html
@@ -1,22 +1,106 @@
+{{- /* Get current path and version for reliable path replacement */ -}}
 {{- $path := .Page.RelPermalink -}}
-{{ $version := .Page.FirstSection.RelPermalink }}
-{{ $newPath := strings.Replace $path $version "" -1 }}
-{{ $baseurl := .Site.BaseURL }}
+{{- $version := .Page.FirstSection.RelPermalink -}}
+{{- $newPath := strings.Replace $path $version "" -1 -}}
+{{- $baseurl := .Site.BaseURL -}}
 
-{{/* If current version uses a subversion, strip it from the path */}}
-{{ $versionTrimmed := trim $version "/" }}
-{{ $versionData := index (where .Site.Params.versions "linkVersion" $versionTrimmed) 0 }}
-{{ range $versionData.subversions }}
-    {{ $newPath = strings.Replace $newPath .id "" 1 }}
-{{ end }}
+{{- /* If current version uses a subversion, strip it from the path */ -}}
+{{- $versionTrimmed := trim $version "/" -}}
+{{- $versionData := index (where .Site.Params.versions "linkVersion" $versionTrimmed) 0 -}}
+{{- if and $versionData $versionData.subversions -}}
+  {{- range $versionData.subversions -}}
+    {{- $newPath = strings.Replace $newPath .id "" 1 -}}
+  {{- end -}}
+{{- end -}}
 
-{{ $newPath = strings.TrimLeft "/" $newPath }}
-{{ range .Site.Params.versions }}
-    {{ $newSubversion := "" }}
-    {{ if .subversions }}
-        {{ $subObj := index (where .subversions "dropdownDefault" true) 0 }}
-        {{ if not $subObj }}{{ $subObj = index .subversions 0 }}{{ end }}
-        {{ $newSubversion = print "/" $subObj.id }}
-    {{ end }}
-    <li><a class="dropdown-item" href="{{ $baseurl }}/{{ .linkVersion }}{{ $newSubversion }}/{{ $newPath }}">{{ .dropdown }}</a></li>
-{{ end }}
+{{- $newPath = strings.TrimLeft "/" $newPath -}}
+
+{{- /* Get current product from config, current version, or URL */ -}}
+{{- $currentProduct := .Site.Params.currentProduct | default "" -}}
+{{- if not $currentProduct -}}
+  {{- /* Try to get product from current version data */ -}}
+  {{- $currentVersionData := index (where .Site.Params.versions "linkVersion" $versionTrimmed) 0 -}}
+  {{- if and $currentVersionData $currentVersionData.product -}}
+    {{- $currentProduct = $currentVersionData.product -}}
+  {{- else -}}
+    {{- /* Fallback: try to get from URL structure */ -}}
+    {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
+    {{- if ge (len $urlParts) 2 -}}
+      {{- $firstPart := index $urlParts 1 -}}
+      {{- $currentProduct = $firstPart -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Group versions by product if products are defined */ -}}
+{{- $allVersions := .Site.Params.versions -}}
+{{- $productsList := slice -}}
+{{- $seenProducts := dict -}}
+{{- range $allVersions -}}
+  {{- if and .product .productName -}}
+    {{- $currentProductId := .product -}}
+    {{- if not (index $seenProducts $currentProductId) -}}
+      {{- $productVersions := where $allVersions "product" $currentProductId -}}
+      {{- $productsList = $productsList | append (dict "id" $currentProductId "name" .productName "versions" $productVersions) -}}
+      {{- $seenProducts = merge $seenProducts (dict $currentProductId true) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $productsList -}}
+  {{- /* Show versions grouped by product */ -}}
+  {{- $totalProducts := len $productsList -}}
+  {{- $currentIndex := 0 -}}
+  {{- range $productsList -}}
+    {{- $currentIndex = add $currentIndex 1 -}}
+    {{- $productId := .id -}}
+    {{- $productName := .name -}}
+    {{- $productVersions := .versions -}}
+    {{- /* Product header */ -}}
+    {{- if $productName -}}
+      <li><h6 class="dropdown-header">{{ $productName }}</h6></li>
+    {{- end -}}
+    {{- /* Versions for this product */ -}}
+    {{- range $productVersions -}}
+      {{- $newSubversion := "" -}}
+      {{- if .subversions -}}
+        {{- $subObj := index (where .subversions "dropdownDefault" true) 0 -}}
+        {{- if not $subObj }}{{ $subObj = index .subversions 0 }}{{ end -}}
+        {{- $newSubversion = print "/" $subObj.id -}}
+      {{- end -}}
+      {{- $isActive := and (in $versionTrimmed .linkVersion) (eq .product $currentProduct) -}}
+      {{- /* Construct URL - always use relative path construction, never use .url field directly */ -}}
+      {{- $versionUrl := "" -}}
+      {{- /* Always construct relative path - works for both localhost and production */ -}}
+      {{- if $newPath -}}
+        {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+      {{- else -}}
+        {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+      {{- end -}}
+      <li><a class="dropdown-item ps-4 {{ if $isActive }}active{{ end }}" href="{{ $versionUrl }}">{{ .dropdown }}</a></li>
+    {{- end -}}
+    {{- /* Add divider between product groups, but not after the last one */ -}}
+    {{- if lt $currentIndex $totalProducts -}}
+      <li><hr class="dropdown-divider"></li>
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- /* Fallback: show all versions without grouping if products not defined */ -}}
+  {{- range $allVersions -}}
+    {{- $newSubversion := "" -}}
+    {{- if .subversions -}}
+      {{- $subObj := index (where .subversions "dropdownDefault" true) 0 -}}
+      {{- if not $subObj }}{{ $subObj = index .subversions 0 }}{{ end -}}
+      {{- $newSubversion = print "/" $subObj.id -}}
+    {{- end -}}
+    {{- /* Construct URL - always use relative path construction, never use .url field directly */ -}}
+    {{- $versionUrl := "" -}}
+    {{- /* Always construct relative path - works for both localhost and production */ -}}
+    {{- if $newPath -}}
+      {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+    {{- else -}}
+      {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+    {{- end -}}
+    <li><a class="dropdown-item" href="{{ $versionUrl }}">{{ .dropdown }}</a></li>
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/docs/navbar-version.html
+++ b/layouts/partials/docs/navbar-version.html
@@ -69,13 +69,19 @@
         {{- $newSubversion = print "/" $subObj.id -}}
       {{- end -}}
       {{- $isActive := and (in $versionTrimmed .linkVersion) (eq .product $currentProduct) -}}
-      {{- /* Construct URL - always use relative path construction, never use .url field directly */ -}}
+      {{- /* Check if switching to a different product */ -}}
+      {{- $isDifferentProduct := and $currentProduct .product (ne .product $currentProduct) -}}
       {{- $versionUrl := "" -}}
-      {{- /* Always construct relative path - works for both localhost and production */ -}}
-      {{- if $newPath -}}
-        {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+      {{- if $isDifferentProduct -}}
+        {{- /* Different product: use the landing page URL */ -}}
+        {{- $versionUrl = .url | default "" -}}
       {{- else -}}
-        {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+        {{- /* Same product: preserve the current path */ -}}
+        {{- if $newPath -}}
+          {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+        {{- else -}}
+          {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+        {{- end -}}
       {{- end -}}
       <li><a class="dropdown-item ps-4 {{ if $isActive }}active{{ end }}" href="{{ $versionUrl }}">{{ .dropdown }}</a></li>
     {{- end -}}
@@ -93,13 +99,19 @@
       {{- if not $subObj }}{{ $subObj = index .subversions 0 }}{{ end -}}
       {{- $newSubversion = print "/" $subObj.id -}}
     {{- end -}}
-    {{- /* Construct URL - always use relative path construction, never use .url field directly */ -}}
+    {{- /* Check if switching to a different product */ -}}
+    {{- $isDifferentProduct := and $currentProduct .product (ne .product $currentProduct) -}}
     {{- $versionUrl := "" -}}
-    {{- /* Always construct relative path - works for both localhost and production */ -}}
-    {{- if $newPath -}}
-      {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+    {{- if $isDifferentProduct -}}
+      {{- /* Different product: use the landing page URL */ -}}
+      {{- $versionUrl = .url | default "" -}}
     {{- else -}}
-      {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+      {{- /* Same product: preserve the current path */ -}}
+      {{- if $newPath -}}
+        {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+      {{- else -}}
+        {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+      {{- end -}}
     {{- end -}}
     <li><a class="dropdown-item" href="{{ $versionUrl }}">{{ .dropdown }}</a></li>
   {{- end -}}

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -31,7 +31,24 @@
         {{ if .Site.Params.versions }}
             {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
             {{- $version := index $urlParts 1 -}}
-            {{ $versionData := index (where .Site.Params.versions "linkVersion" $version) 0 }}
+            {{- /* Get current product to filter version data correctly */ -}}
+            {{- $currentProduct := .Site.Params.currentProduct | default "" -}}
+            {{- if not $currentProduct -}}
+              {{- /* Try to get product from current version data */ -}}
+              {{- $currentVersionData := index (where .Site.Params.versions "linkVersion" $version) 0 -}}
+              {{- if and $currentVersionData $currentVersionData.product -}}
+                {{- $currentProduct = $currentVersionData.product -}}
+              {{- else -}}
+                {{- /* Fallback: try to get from URL structure */ -}}
+                {{- $currentProduct = index $urlParts 0 -}}
+              {{- end -}}
+            {{- end -}}
+            {{- /* Find version data matching both version and product */ -}}
+            {{- $matchingVersions := where .Site.Params.versions "linkVersion" $version -}}
+            {{- if $currentProduct -}}
+              {{- $matchingVersions = where $matchingVersions "product" $currentProduct -}}
+            {{- end -}}
+            {{ $versionData := index $matchingVersions 0 }}
             {{ $showSidebar = or (not $versionData.subversions) (index $urlParts 2) }}
             {{ if and $versionData.subversions $showSidebar }}
                 {{- $subversion := index $urlParts 2 -}}
@@ -54,7 +71,24 @@
                 {{ if not $showSidebar}} {{break}} {{ end }}
                 {{ $subversionToCheck := false }}
                 {{ if .Site.Params.versions }}
-                    {{ $versionData := index (where .Site.Params.versions "linkVersion" .Section) 0 }}
+                    {{- /* Get current product to filter version data correctly */ -}}
+                    {{- $currentProductForSection := .Site.Params.currentProduct | default "" -}}
+                    {{- if not $currentProductForSection -}}
+                      {{- /* Try to get product from current version data */ -}}
+                      {{- $currentVersionDataForSection := index (where .Site.Params.versions "linkVersion" .Section) 0 -}}
+                      {{- if and $currentVersionDataForSection $currentVersionDataForSection.product -}}
+                        {{- $currentProductForSection = $currentVersionDataForSection.product -}}
+                      {{- else -}}
+                        {{- /* Fallback: try to get from URL structure */ -}}
+                        {{- $currentProductForSection = index $urlParts 0 -}}
+                      {{- end -}}
+                    {{- end -}}
+                    {{- /* Find version data matching both version and product */ -}}
+                    {{- $matchingVersionsForSection := where .Site.Params.versions "linkVersion" .Section -}}
+                    {{- if $currentProductForSection -}}
+                      {{- $matchingVersionsForSection = where $matchingVersionsForSection "product" $currentProductForSection -}}
+                    {{- end -}}
+                    {{ $versionData := index $matchingVersionsForSection 0 }}
                     {{ if and $versionData $versionData.subversions }}
                         {{ range $urlParts }}
                             {{ if (where $versionData.subversions "id" "eq" .) | len }}

--- a/layouts/partials/docs/top-header.html
+++ b/layouts/partials/docs/top-header.html
@@ -51,14 +51,53 @@
                     <button class="btn btn-link btn-default dropdown-toggle ps-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         {{- $versionLong := .Page.FirstSection.RelPermalink -}}
                         {{- $version := trim $versionLong "/" -}}
+                        {{- $currentVersionData := "" -}}
+                        {{- $currentProduct := .Site.Params.currentProduct | default "" -}}
+                        {{- /* First, try to find current version to get its product */ -}}
                         {{- range .Site.Params.versions -}}
+                          {{- if in $version .linkVersion -}}
+                            {{- $currentVersionData = . -}}
+                            {{- /* If we don't have currentProduct, get it from the version */ -}}
+                            {{- if not $currentProduct -}}
+                              {{- if .product -}}
+                                {{- $currentProduct = .product -}}
+                              {{- end -}}
+                            {{- end -}}
+                            {{- break -}}
+                          {{- end -}}
+                        {{- end -}}
+                        {{- /* If we still don't have currentProduct and currentVersionData, try URL fallback */ -}}
+                        {{- if not $currentProduct -}}
+                          {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
+                          {{- if ge (len $urlParts) 2 -}}
+                            {{- $firstPart := index $urlParts 1 -}}
+                            {{- $currentProduct = $firstPart -}}
+                          {{- end -}}
+                        {{- end -}}
+                        {{- /* Re-find current version with product context if needed */ -}}
+                        {{- if not $currentVersionData -}}
+                          {{- range .Site.Params.versions -}}
+                            {{- if and (in $version .linkVersion) (or (not $currentProduct) (eq .product $currentProduct)) -}}
+                              {{- $currentVersionData = . -}}
+                              {{- break -}}
+                            {{- end -}}
+                          {{- end -}}
+                        {{- end -}}
+                        {{- if and $currentVersionData $currentVersionData.product $currentVersionData.productName -}}
+                          {{ $currentVersionData.productName }} - {{ $currentVersionData.dropdown }}
+                        {{- else if $currentVersionData -}}
+                          {{ $currentVersionData.dropdown }}
+                        {{- else -}}
+                          {{- /* Fallback to original behavior */ -}}
+                          {{- range .Site.Params.versions -}}
                             {{- if in $version .linkVersion -}}
                               {{- printf .dropdown -}}
-                            {{ break }}
+                              {{ break }}
                             {{- end -}}
+                          {{- end -}}
                         {{- end -}}
                     </button>
-                    <ul class="dropdown-menu text-end">
+                    <ul class="dropdown-menu">
                         {{ partial (printf "%s/%s" ($.Scratch.Get "pathName") "navbar-version") . }} 
                     </ul>
                 </div>

--- a/layouts/partials/docs/versionspecificbanner.html
+++ b/layouts/partials/docs/versionspecificbanner.html
@@ -7,8 +7,27 @@
 {{/* If current version uses a subversion, strip it from the path */}}
 {{ $versionTrimmed := trim $trimmedPath "/" }}
 
+{{- /* Get current product from config, current version, or URL */ -}}
+{{- $currentProduct := .Site.Params.currentProduct | default "" -}}
+{{- if not $currentProduct -}}
+  {{- /* Try to get product from current version data */ -}}
+  {{- $currentVersionData := index (where .Site.Params.versions "linkVersion" $versionTrimmed) 0 -}}
+  {{- if and $currentVersionData $currentVersionData.product -}}
+    {{- $currentProduct = $currentVersionData.product -}}
+  {{- else -}}
+    {{- /* Fallback: try to get from URL structure */ -}}
+    {{- $urlParts := strings.Split .Page.RelPermalink "/" -}}
+    {{- if ge (len $urlParts) 2 -}}
+      {{- $firstPart := index $urlParts 1 -}}
+      {{- $currentProduct = $firstPart -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{ range .Site.Params.versions }}
-  {{ if or (eq .version $version) (eq .version $versionTrimmed) }}
+  {{- $versionMatches := or (eq .version $version) (eq .version $versionTrimmed) -}}
+  {{- $productMatches := or (not $currentProduct) (eq .product $currentProduct) -}}
+  {{ if and $versionMatches $productMatches }}
    {{ if ne .banner "" }}
    <div class="alert alert-info d-flex">
        <div class="w-100">


### PR DESCRIPTION
### Changes

Updates the navbar, header, and banner logic to use new productName in the params.versions of the toml. This way, we can get a version dropdown that has multiple versions.

- version dropdown grouped by version
- left-alignment and product name rendering
- keeps version switcher within the same product, e.g., 1.17.x/about/architecture switches to 1.19.x/about/architecture
- if a diff product, goes to that product version's landing page in params.versions.url, such as https://docs.solo.io/kgateway/2.1.x
- prevents duplicate banners from showing by filtering by product

> [!NOTE]
> Gateway-family docs toml and theme bump updates in https://github.com/solo-io/docs/pull/1643

Local preview:
<img width="1705" height="638" alt="image" src="https://github.com/user-attachments/assets/927d9fa7-d133-4099-916d-63c12aed545f" />
