### PR TITLE
[fix] version switcher for prod and localhost

### DIFF
--- a/layouts/partials/docs/navbar-version.html
+++ b/layouts/partials/docs/navbar-version.html
@@ -3,6 +3,17 @@
 {{- $version := .Page.FirstSection.RelPermalink -}}
 {{- $newPath := strings.Replace $path $version "" -1 -}}
 {{- $baseurl := .Site.BaseURL -}}
+{{- $folder := .Site.Params.folder | default "" -}}
+
+{{- /* Determine if we should include folder in path based on current URL structure */ -}}
+{{- $includeFolder := false -}}
+{{- if $folder -}}
+  {{- /* Check if current path includes the folder (production scenario) */ -}}
+  {{- $folderPath := printf "/%s/" $folder -}}
+  {{- if strings.HasPrefix $path $folderPath -}}
+    {{- $includeFolder = true -}}
+  {{- end -}}
+{{- end -}}
 
 {{- /* If current version uses a subversion, strip it from the path */ -}}
 {{- $versionTrimmed := trim $version "/" -}}
@@ -77,10 +88,20 @@
         {{- $versionUrl = .url | default "" -}}
       {{- else -}}
         {{- /* Same product: preserve the current path */ -}}
-        {{- if $newPath -}}
-          {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+        {{- if $includeFolder -}}
+          {{- /* Include folder in path when current URL includes it (production) */ -}}
+          {{- if $newPath -}}
+            {{- $versionUrl = printf "/%s/%s%s/%s" $folder .linkVersion $newSubversion $newPath -}}
+          {{- else -}}
+            {{- $versionUrl = printf "/%s/%s%s/" $folder .linkVersion $newSubversion -}}
+          {{- end -}}
         {{- else -}}
-          {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+          {{- /* No folder: use relative path (localhost) */ -}}
+          {{- if $newPath -}}
+            {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+          {{- else -}}
+            {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+          {{- end -}}
         {{- end -}}
       {{- end -}}
       <li><a class="dropdown-item ps-4 {{ if $isActive }}active{{ end }}" href="{{ $versionUrl }}">{{ .dropdown }}</a></li>
@@ -107,10 +128,20 @@
       {{- $versionUrl = .url | default "" -}}
     {{- else -}}
       {{- /* Same product: preserve the current path */ -}}
-      {{- if $newPath -}}
-        {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+      {{- if $includeFolder -}}
+        {{- /* Include folder in path when current URL includes it (production) */ -}}
+        {{- if $newPath -}}
+          {{- $versionUrl = printf "/%s/%s%s/%s" $folder .linkVersion $newSubversion $newPath -}}
+        {{- else -}}
+          {{- $versionUrl = printf "/%s/%s%s/" $folder .linkVersion $newSubversion -}}
+        {{- end -}}
       {{- else -}}
-        {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+        {{- /* No folder: use relative path (localhost) */ -}}
+        {{- if $newPath -}}
+          {{- $versionUrl = printf "/%s%s/%s" .linkVersion $newSubversion $newPath -}}
+        {{- else -}}
+          {{- $versionUrl = printf "/%s%s/" .linkVersion $newSubversion -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
     <li><a class="dropdown-item" href="{{ $baseurl }}{{ $versionUrl }}">{{ .dropdown }}</a></li>


### PR DESCRIPTION
### Problem

Following up on #50 and #51, now that we have pushed the @docs/hugo-gateway.toml site out to production, we're seeing an issue with the product version dropdown switcher.

If I am on a page such as:
https://docs.solo.io/gateway/2.0.x/about/architecture/ 

and then try to use the dropdown to switch versions to 1.19.x in the same Gloo Gateway product.

But when I click 1.19.x, it takes me to:
https://www.solo.io/docs1.19.x/about/architecture 
so it is missing the /gateway/ product base URL between solo.io/docs and the version 1.19.x

Doc sets that do not use the product version dropdown switcher yet (like Mesh) do not have this issue.

### Changes

The issue: when baseURL is https://docs.solo.io/gateway, relative paths like /1.19.x/about/architecture/ resolve relative to the domain root, not the baseURL. We should include the product folder in the path.

- Updates the logic to account for the folder parameter
- keeps relative path for localhost scenarios so it still works when you build locally

### Tests
I pushed this to the firebase preview channel and it works there. For example if you go:

https://gateway-k8s-api--gateway-k8s-api-vonluadm.web.app/gateway/1.19.x/about/

and then you can switch to 1.20 etc.

