### PR TITLE
Keep banner on each page

### DIFF
--- a/layouts/partials/docs/versionspecificbanner.html
+++ b/layouts/partials/docs/versionspecificbanner.html
@@ -6,6 +6,9 @@
 {{ $trimmedPath := strings.Replace $pathprod .Site.Params.folder "" -1 }}
 {{/* If current version uses a subversion, strip it from the path */}}
 {{ $versionTrimmed := trim $trimmedPath "/" }}
+{{/* Extract just the version part from trimmed path */}}
+{{ $trimmedParts := split $versionTrimmed "/" }}
+{{ $versionTrimmed = index $trimmedParts 0 }}
 
 {{- /* Get current product from config, current version, or URL */ -}}
 {{- $currentProduct := .Site.Params.currentProduct | default "" -}}
@@ -25,7 +28,7 @@
 {{- end -}}
 
 {{ range .Site.Params.versions }}
-  {{- $versionMatches := or (eq .version $version) (eq .version $versionTrimmed) -}}
+  {{- $versionMatches := or (eq .linkVersion $version) (eq .linkVersion $versionTrimmed) -}}
   {{- $productMatches := or (not $currentProduct) (eq .product $currentProduct) -}}
   {{ if and $versionMatches $productMatches }}
    {{ if ne .banner "" }}


### PR DESCRIPTION
Updates the banner code so that it will be displayed on every page in a version. Previously, the banner was _only_ showing on the landing page for any version (e.g., https://docs.solo.io/kgateway/2.1.x/) but if you go to any other page, or start on any other page, you dont see it (e.g., https://docs.solo.io/kgateway/2.1.x/quickstart/)