### PR TITLE
Updated link for the home page

### DIFF
--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -1,12 +1,12 @@
 <!-- sidebar-wrapper -->
 <nav id="sidebar" class="sidebar-wrapper">
     <div class="sidebar-brand">
-                <a href='https://docs.solo.io' aria-label="HomePage" alt="HomePage" class="toggle-dark">
+                <a href='https://www.solo.io/docs' aria-label="HomePage" alt="HomePage" class="toggle-dark">
                     {{ with resources.Get "images/logos/logo.svg" }}
                         {{ .Content | safeHTML }}
                     {{ end }}
                 </a>
-                <a href='https://docs.solo.io' aria-label="HomePage" alt="HomePage" class="toggle-light">
+                <a href='https://www.solo.io/docs' aria-label="HomePage" alt="HomePage" class="toggle-light">
                     {{ with resources.Get "images/logos/logo-dark.svg" }}
                         {{ .Content | safeHTML }}
                     {{ end }}


### PR DESCRIPTION
Updates the link in the Home logo to avoid redirect warnings in the link checker.
https://docs.solo.io -> https://www.solo.io/docs

Tested locally by creating a temporary sidebar.html file.